### PR TITLE
Add Auto-Mod webhook relay

### DIFF
--- a/events/messageCreate/autoModRelay.js
+++ b/events/messageCreate/autoModRelay.js
@@ -1,0 +1,49 @@
+const { WebhookClient } = require('discord.js');
+const path = require('node:path');
+const fs = require('fs');
+
+const WEBHOOK_NAME = 'ModBotRelay';
+const AVATAR_PATH = path.join(__dirname, '../../assets/modbot_avatar.png');
+
+let avatarBuffer;
+try {
+  avatarBuffer = fs.readFileSync(AVATAR_PATH);
+} catch {
+  avatarBuffer = null;
+}
+
+module.exports = async message => {
+  if (message.author.bot || !message.guild) return;
+
+  const prefixRegex = /^auto-mod:/i;
+  if (!prefixRegex.test(message.content)) return;
+
+  const relayContent = message.content.replace(prefixRegex, '').trim();
+  if (!relayContent) return;
+
+  try {
+    await message.delete();
+  } catch (err) {
+    console.error('Failed to delete Auto-Mod trigger:', err);
+  }
+
+  try {
+    let hook;
+    const hooks = await message.channel.fetchWebhooks().catch(() => null);
+    if (hooks) hook = hooks.find(h => h.name === WEBHOOK_NAME);
+
+    if (!hook) {
+      const createOpts = { name: WEBHOOK_NAME };
+      if (avatarBuffer) createOpts.avatar = avatarBuffer;
+      hook = await message.channel.createWebhook(createOpts).catch(() => null);
+    }
+
+    if (!hook) return;
+
+    if (avatarBuffer) await hook.edit({ avatar: avatarBuffer }).catch(() => {});
+
+    await hook.send({ content: relayContent, username: WEBHOOK_NAME });
+  } catch (err) {
+    console.error('Failed to relay Auto-Mod message:', err);
+  }
+};


### PR DESCRIPTION
## Summary
- implement `autoModRelay.js` to allow posting messages as Auto-Mod via webhook

## Testing
- `node -c events/messageCreate/autoModRelay.js`
- `node -c index.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866ae6588748333aec01c33269c799d