### PR TITLE
Fix invalid regex for OnlyFans leak detection

### DIFF
--- a/config/mod_rules.yaml
+++ b/config/mod_rules.yaml
@@ -313,3 +313,9 @@ rules:
     pattern: "(?:boost(?:ing)?(?: this)? server|server boost).*win"
     action: flag_and_hide
     reason: "Boost bait scam"
+
+  # 🔞 Adult / OnlyFans Scams
+  - id: scam_onlyfans_leak_invite
+    pattern: "(?:🔞|18\+|adult)?\s*(?:[o0оОØØ]n?l?y?f[a@4]n[s5]?|олнyфaнs?)\s*leaks?\b.*join"
+    action: flag_and_hide
+    reason: "OnlyFans leak server invite"


### PR DESCRIPTION
## Summary
- add new Node-compatible regex for detecting OnlyFans leak invites

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a7bc5df788333a1ac80b8faf8d1c7