### PR TITLE
Fix YAML escape in OnlyFans rule

### DIFF
--- a/config/mod_rules.yaml
+++ b/config/mod_rules.yaml
@@ -316,6 +316,6 @@ rules:
 
   # 🔞 Adult / OnlyFans Scams
   - id: scam_onlyfans_leak_invite
-    pattern: "(?:🔞|18\+|adult)?\s*(?:[o0оОØØ]n?l?y?f[a@4]n[s5]?|олнyфaнs?)\s*leaks?\b.*join"
+    pattern: '(?:🔞|18\+|adult)?\s*(?:[o0оОØØ]n?l?y?f[a@4]n[s5]?|олнyфaнs?)\s*leaks?\b.*join'
     action: flag_and_hide
     reason: "OnlyFans leak server invite"


### PR DESCRIPTION
## Summary
- escape regex pattern correctly by using single quotes

## Testing
- `python3 - <<'PY'
import yaml
data = yaml.safe_load(open('config/mod_rules.yaml'))
print(len(data['rules']))
print(data['rules'][-1])
PY`

------
https://chatgpt.com/codex/tasks/task_e_686a7e97912483338782daad9aea124d