### PR TITLE
Refine automod rule for "check this out"

### DIFF
--- a/config/mod_rules.yaml
+++ b/config/mod_rules.yaml
@@ -254,7 +254,7 @@ rules:
     reason: "Suspicious link"
 
   - id: scam_check_this_out
-    pattern: "check this out"
+    pattern: "\\bcheck this out\\b.*(?:https?://|www\\.|discord\\.(?:gg|com))"
     action: flag_and_hide
     reason: "Suspicious prompt"
 


### PR DESCRIPTION
## Summary
- fix false positives by scoping the `scam_check_this_out` pattern to cases where the phrase is followed by a link

## Testing
- `python - <<'EOF'
import yaml
yaml.safe_load(open('config/mod_rules.yaml'))
print('YAML parse success')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68780c3e5d288333a404e88199a72819