### PR TITLE
Fix Python path and deprecated API usage

### DIFF
--- a/events/interactionCreate/handlerecaps.js
+++ b/events/interactionCreate/handlerecaps.js
@@ -1,6 +1,7 @@
 const recap = require('../../models/recap');
 const formatResults = require('../../utils/formatResults');
 const adventurers = require('../../models/adventurers');
+const { InteractionResponseFlags } = require('discord.js');
 
 
 /**
@@ -24,7 +25,7 @@ module.exports = async (interaction, client) => {
 		if (!type || !recapId || !action) return false;
 		if (type !== 'recap') return false;
 
-		await interaction.deferReply({ ephemeral: true });
+                await interaction.deferReply({ flags: InteractionResponseFlags.Ephemeral });
 
 		const targetrecap = await recap.findOne({ recapId });
 		const targetMessage = await interaction.channel.messages.fetch(targetrecap.messageId);

--- a/events/messageCreate/freeAI.js
+++ b/events/messageCreate/freeAI.js
@@ -88,13 +88,9 @@ function generateWebhookURL(discordThreadId) {
 	}
 }
 
-// keep your existing Python‐script path helper exactly as is
+// Resolve the Python script path relative to the repository root
 function getPythonScriptPath() {
-	const homeDirectory = os.homedir();
-        return path.join(
-                homeDirectory,
-                'LFGDIscordBot/utils/langchainPythonRAG.py',
-        );
+        return path.join(__dirname, '..', '..', 'utils', 'langchainPythonRAG.py');
 }
 
 // askQuestion uses that helper


### PR DESCRIPTION
## Summary
- resolve python script path in freeAI handler using `__dirname`
- switch ephemeral response to flags API to silence deprecation

## Testing
- `npm install` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687a76bf196c833381f09a05f8c83fa8