### PR TITLE
feat(moderation): add soft flag approvals

### DIFF
--- a/config/mod_rules.yaml
+++ b/config/mod_rules.yaml
@@ -3,6 +3,7 @@ rules:
   - id: scam_free_macbook
     pattern: "free macbook"
     action: flag_and_hide
+    priority: primary
     reason: "Fake giveaway: Free MacBook"
 
   - id: scam_giving_laptop
@@ -114,6 +115,7 @@ rules:
   - id: scam_reward_claim
     pattern: "claim your reward"
     action: flag_and_hide
+    priority: secondary
     reason: "Reward scam"
 
   - id: scam_easy_money

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -1,0 +1,4 @@
+# Moderation System Notes
+
+- Auto-approve of secondary flags runs in-process via a worker loop. If the bot is offline, pending items will not be processed until it restarts. External monitoring is recommended for long outages.
+- The bot requires the following permissions in all moderated channels: **Manage Webhooks**, **Manage Messages**, **Read Message History**, and **Send Messages**.

--- a/events/interactionCreate/handleModeration.js
+++ b/events/interactionCreate/handleModeration.js
@@ -1,8 +1,7 @@
 // src/events/interactionCreate/handleModeration.js
-const handleModerationButtons = require('../../moderation/moderationActions');
+const handleModerationInteractions = require('../../moderation/moderationActions');
 
 module.exports = async (interaction, client) => {
-  // only care about button presses
-  if (!interaction.isButton()) return;
-  await handleModerationButtons(client, interaction);
+  if (!interaction.isButton() && !interaction.isModalSubmit()) return;
+  await handleModerationInteractions(client, interaction);
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const helmet = require('helmet');
 const { Client, GatewayIntentBits } = require('discord.js');
 const mongoose = require('mongoose');
 const { CommandKit } = require('commandkit');
+const startAutoApproveWorker = require('./moderation/autoApproveWorker');
 
 // Discord Client Setup
 const client = new Client({
@@ -22,6 +23,10 @@ new CommandKit({
 	eventsPath:   path.join(__dirname, 'events'),
 	commandsPath: path.join(__dirname, 'commands'),
 	bulkRegister: false,
+});
+
+client.once('ready', () => {
+        startAutoApproveWorker(client);
 });
 
 // Mongoose Setup

--- a/moderation/autoApproveWorker.js
+++ b/moderation/autoApproveWorker.js
@@ -1,0 +1,35 @@
+// moderation/autoApproveWorker.js
+const redis = require('../utils/redis');
+const getOrCreateWebhook = require('../utils/webhooks');
+
+const LOG_CHANNEL_ID = process.env.LOG_CHANNEL_ID || '983865514751320124';
+
+module.exports = function startAutoApproveWorker(client) {
+  setInterval(async () => {
+    try {
+      const now = Date.now();
+      const ids = await redis.zRangeByScore('autoApproveQueue', 0, now);
+      for (const id of ids) {
+        const raw = await redis.get(`flag:${id}`);
+        if (!raw) {
+          await redis.zRem('autoApproveQueue', id);
+          continue;
+        }
+        const flag = JSON.parse(raw);
+        if (flag.status === 'pending' && flag.autoApproveAt && flag.autoApproveAt <= now) {
+          flag.status = 'approved';
+          await redis.set(`flag:${id}`, JSON.stringify(flag));
+          await redis.zRem('autoApproveQueue', id);
+          const channel = await client.channels.fetch(flag.channelId).catch(() => null);
+          const hook = channel ? await getOrCreateWebhook(channel) : null;
+          if (hook) await hook.send({ content: '✅ Auto-approved after 24h.', username: 'ModBotRelay' });
+          const logChannel = await client.channels.fetch(LOG_CHANNEL_ID).catch(() => null);
+          const logHook = logChannel ? await getOrCreateWebhook(logChannel) : null;
+          if (logHook) await logHook.send({ content: `Auto-approved message ${id}`, username: 'ModBot' });
+        }
+      }
+    } catch (err) {
+      console.error('Auto-approve worker error:', err);
+    }
+  }, 60 * 1000);
+};

--- a/moderation/moderationActions.js
+++ b/moderation/moderationActions.js
@@ -1,7 +1,10 @@
 // moderation/moderationActions.js
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
 const path = require('node:path');
 const fs   = require('fs');
+
+const redis = require('../utils/redis');
+const getOrCreateWebhook = require('../utils/webhooks');
 
 const LOG_CHANNEL_ID     = process.env.LOG_CHANNEL_ID || '983865514751320124';
 const WEBHOOK_NAME       = 'ModBot';
@@ -13,119 +16,202 @@ let vibeBuffer, hammerBuffer;
 try { vibeBuffer  = fs.readFileSync(VIBE_AVATAR_PATH);   } catch {}
 try { hammerBuffer = fs.readFileSync(HAMMER_AVATAR_PATH); } catch {}
 
-module.exports = async function handleModerationButtons(client, interaction) {
-  if (!interaction.isButton()) return;
+async function logAction(client, action, userField, mod, channelField, reason, content, embedFooter) {
+  const logChannel = await client.channels.fetch(LOG_CHANNEL_ID).catch(() => null);
+  if (!logChannel || !logChannel.isTextBased()) return;
+  let hook = (await logChannel.fetchWebhooks().catch(() => null))?.find(h => h.name === WEBHOOK_NAME);
+  if (!hook) {
+    hook = await logChannel.createWebhook({
+      name:   WEBHOOK_NAME,
+      avatar: vibeBuffer || client.user.displayAvatarURL({ dynamic: true }),
+      reason: 'Mod log webhook'
+    }).catch(console.error);
+  }
+  if (!hook) return;
+  const avatar = action === 'ban' ? hammerBuffer : vibeBuffer;
+  if (avatar) await hook.edit({ avatar }).catch(console.error);
 
+  const logEmbed = new EmbedBuilder()
+    .setTitle('📝 Moderation Action')
+    .setColor(action === 'ban' ? 0xff0000 : action === 'warn' ? 0xffa500 : 0x00ff00)
+    .addFields(
+      { name: 'Action',       value: action.toUpperCase(),             inline: true },
+      { name: 'User',         value: userField,                       inline: true },
+      { name: 'Moderator',    value: `${mod.tag} (<@${mod.id}>)`,     inline: true },
+      { name: 'Channel',      value: channelField,                    inline: false },
+      { name: 'Reason',       value: reason,                          inline: false },
+      { name: 'Original Msg', value: content?.slice(0, 1000) || '',   inline: false }
+    )
+    .setFooter({ text: embedFooter || 'N/A' })
+    .setTimestamp();
+  await hook.send({ embeds: [logEmbed], username: WEBHOOK_NAME }).catch(console.error);
+}
+
+module.exports = async function handleModerationInteractions(client, interaction) {
   try {
-    const [action, messageId] = interaction.customId.split('_');
-    const mod = interaction.user;
+    if (interaction.isButton()) {
+      const [action, messageId] = interaction.customId.split('_');
+      const mod = interaction.user;
 
-    // grab embed context
-    const modAlert = interaction.message;
-    const embedData = modAlert.embeds[0];
-    const userField    = embedData.fields.find(f => f.name === 'User')?.value;
-    const channelField = embedData.fields.find(f => f.name === 'Channel')?.value;
-    const reason       = embedData.fields.find(f => f.name === 'Reason')?.value;
-    const content      = embedData.fields.find(f => f.name === 'Content')?.value;
-
-    // extract user ID
-    const userIdMatch = /<@(\d+)>/.exec(userField || '');
-    const userId = userIdMatch ? userIdMatch[1] : null;
-
-    let resultText = '';
-
-    switch (action) {
-      case 'warn':
-        if (userId) {
-          const member = await interaction.guild.members.fetch(userId).catch(() => null);
-          if (member) {
-            const dmEmbed = new EmbedBuilder()
-              .setTitle('⚠️ Your message was flagged')
-              .setColor(0xffa500)
-              .addFields(
-                { name: 'Reason',        value: reason,                   inline: false },
-                { name: 'Your message',  value: content?.slice(0, 1000) || '', inline: false },
-                { name: 'Next steps',    value: 'Please review our guidelines.', inline: false }
-              );
-            await member.send({ embeds: [dmEmbed] }).catch(console.error);
-          }
-        }
-        await interaction.reply({ content: `⚠️ Warned ${userField}.`, ephemeral: true });
-        resultText = `Warned ${userField}`;
-        break;
-
-      case 'ban':
-        if (!userId) {
-          await interaction.reply({ content: '❌ Unable to extract user ID.', ephemeral: true });
-          return;
-        }
-        {
-          const member = await interaction.guild.members.fetch(userId).catch(() => null);
-          if (!member) {
-            await interaction.reply({ content: '❌ User not found in this guild.', ephemeral: true });
-            return;
-          }
-          if (!member.bannable) {
-            await interaction.reply({ content: '❌ Cannot ban this user (check permissions/role hierarchy).', ephemeral: true });
-            return;
-          }
-          try {
-            await member.ban({ reason: 'Scam/Spam auto-mod' });
-          } catch (banErr) {
-            console.error('Failed to ban user:', banErr);
-            await interaction.reply({ content: '❌ An error occurred while banning the user.', ephemeral: true });
-            return;
-          }
-        }
-        await interaction.reply({ content: '🔨 Banned user.', ephemeral: true });
-        resultText = `Banned ${userField}`;
-        break;
-
-      case 'allow':
-        await interaction.reply({ content: '✅ Approved. Please ask the user to repost their message.', ephemeral: true });
-        resultText = `Allowed ${userField}`;
-        break;
-
-      default:
-        await interaction.reply({ content: '❗ Unknown action.', ephemeral: true });
+      // load flag record
+      let flag = await redis.get(`flag:${messageId}`);
+      if (flag) flag = JSON.parse(flag); else flag = null;
+      if (flag && flag.status !== 'pending' && action !== 'warn' && action !== 'ban') {
+        await interaction.reply({ content: 'This flag has already been handled.', ephemeral: true });
         return;
-    }
-
-    // log to mod-log via webhook
-    const logChannel = await client.channels.fetch(LOG_CHANNEL_ID).catch(() => null);
-    if (logChannel && logChannel.isTextBased()) {
-      let hook = (await logChannel.fetchWebhooks().catch(() => null))?.find(h => h.name === WEBHOOK_NAME);
-      if (!hook) {
-        hook = await logChannel.createWebhook({
-          name:   WEBHOOK_NAME,
-          avatar: vibeBuffer || client.user.displayAvatarURL({ dynamic: true }),
-          reason: 'Mod log webhook'
-        }).catch(console.error);
       }
-      if (hook) {
-        const avatar = action === 'ban' ? hammerBuffer : vibeBuffer;
-        if (avatar) await hook.edit({ avatar }).catch(console.error);
 
-        const logEmbed = new EmbedBuilder()
-          .setTitle('📝 Moderation Action')
-          .setColor(action === 'ban' ? 0xff0000 : action === 'warn' ? 0xffa500 : 0x00ff00)
-          .addFields(
-            { name: 'Action',       value: action.toUpperCase(),             inline: true },
-            { name: 'User',         value: userField,                       inline: true },
-            { name: 'Moderator',    value: `${mod.tag} (<@${mod.id}>)`,     inline: true },
-            { name: 'Channel',      value: channelField,                    inline: false },
-            { name: 'Reason',       value: reason,                          inline: false },
-            { name: 'Original Msg', value: content?.slice(0, 1000) || '',     inline: false }
-          )
-          .setFooter({ text: `Rule ID: ${embedData.footer?.text || 'N/A'}` })
-          .setTimestamp();
-        await hook.send({ embeds: [logEmbed], username: WEBHOOK_NAME }).catch(console.error);
+      // grab embed context
+      const modAlert = interaction.message;
+      const embedData = modAlert.embeds[0] || {};
+      const userField    = embedData.fields?.find(f => f.name === 'User')?.value || '';
+      const channelField = embedData.fields?.find(f => f.name === 'Channel')?.value || '';
+      const reason       = embedData.fields?.find(f => f.name === 'Reason')?.value || '';
+      const content      = embedData.fields?.find(f => f.name === 'Content')?.value || '';
+
+      // extract user ID
+      const userIdMatch = /<@(\d+)>/.exec(userField || '');
+      const userId = userIdMatch ? userIdMatch[1] : null;
+
+      let resultText = '';
+
+      switch (action) {
+        case 'warn':
+          if (userId) {
+            const member = await interaction.guild.members.fetch(userId).catch(() => null);
+            if (member) {
+              const dmEmbed = new EmbedBuilder()
+                .setTitle('⚠️ Your message was flagged')
+                .setColor(0xffa500)
+                .addFields(
+                  { name: 'Reason',        value: reason,                   inline: false },
+                  { name: 'Your message',  value: content?.slice(0, 1000) || '', inline: false },
+                  { name: 'Next steps',    value: 'Please review our guidelines.', inline: false }
+                );
+              await member.send({ embeds: [dmEmbed] }).catch(() => {});
+            }
+          }
+          await interaction.reply({ content: `⚠️ Warned ${userField}.`, ephemeral: true });
+          resultText = `Warned ${userField}`;
+          break;
+        case 'ban':
+          if (!userId) {
+            await interaction.reply({ content: '❌ Unable to extract user ID.', ephemeral: true });
+            return;
+          }
+          {
+            const member = await interaction.guild.members.fetch(userId).catch(() => null);
+            if (!member) {
+              await interaction.reply({ content: '❌ User not found in this guild.', ephemeral: true });
+              return;
+            }
+            if (!member.bannable) {
+              await interaction.reply({ content: '❌ Cannot ban this user (check permissions/role hierarchy).', ephemeral: true });
+              return;
+            }
+            try {
+              await member.ban({ reason: 'Scam/Spam auto-mod' });
+            } catch (banErr) {
+              console.error('Failed to ban user:', banErr);
+              await interaction.reply({ content: '❌ An error occurred while banning the user.', ephemeral: true });
+              return;
+            }
+          }
+          await interaction.reply({ content: '🔨 Banned user.', ephemeral: true });
+          resultText = `Banned ${userField}`;
+          break;
+        case 'allow':
+          await interaction.reply({ content: '✅ Approved. Please ask the user to repost their message.', ephemeral: true });
+          resultText = `Allowed ${userField}`;
+          if (flag) {
+            flag.status = 'approved';
+            await redis.set(`flag:${messageId}`, JSON.stringify(flag));
+          }
+          break;
+        case 'approve':
+          await interaction.reply({ content: '✅ Approved.', ephemeral: true });
+          resultText = `Approved ${userField}`;
+          if (flag) {
+            flag.status = 'approved';
+            await redis.set(`flag:${messageId}`, JSON.stringify(flag));
+            await redis.zRem('autoApproveQueue', messageId).catch(() => {});
+          }
+          break;
+        case 'approveRepost':
+          // show modal
+          const modal = new ModalBuilder()
+            .setCustomId(`repostModal_${messageId}`)
+            .setTitle('Approve & Repost');
+          const note = new TextInputBuilder()
+            .setCustomId('note')
+            .setLabel('Moderator note (optional)')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(false)
+            .setMaxLength(500);
+          modal.addComponents(new ActionRowBuilder().addComponents(note));
+          await interaction.showModal(modal);
+          return;
+        case 'delete':
+          if (flag) {
+            try {
+              const channel = await client.channels.fetch(flag.channelId).catch(() => null);
+              if (channel) {
+                const msg = await channel.messages.fetch(flag.messageId).catch(() => null);
+                if (msg) await msg.delete().catch(() => {});
+              }
+              flag.status = 'deleted';
+              await redis.set(`flag:${messageId}`, JSON.stringify(flag));
+              await redis.zRem('autoApproveQueue', messageId).catch(() => {});
+            } catch (err) {
+              console.error('Delete action failed', err);
+            }
+          }
+          await interaction.reply({ content: '🗑️ Message deleted.', ephemeral: true });
+          resultText = `Deleted ${userField}`;
+          break;
+        default:
+          await interaction.reply({ content: '❗ Unknown action.', ephemeral: true });
+          return;
       }
+
+      await logAction(client, action, userField, mod, channelField, reason, content, embedData.footer?.text);
+      await modAlert.delete().catch(() => {});
+    } else if (interaction.isModalSubmit()) {
+      const [prefix, messageId] = interaction.customId.split('_');
+      if (prefix !== 'repostModal') return;
+      let flag = await redis.get(`flag:${messageId}`);
+      if (!flag) {
+        await interaction.reply({ content: 'Flag record missing.', ephemeral: true });
+        return;
+      }
+      flag = JSON.parse(flag);
+      if (flag.status !== 'pending') {
+        await interaction.reply({ content: 'Already processed.', ephemeral: true });
+        return;
+      }
+      const note = interaction.fields.getTextInputValue('note') || '';
+      try {
+       const channel = await interaction.client.channels.fetch(flag.channelId).catch(() => null);
+       const hook = await getOrCreateWebhook(channel);
+        if (hook) {
+          const msg = {
+            content: `✅ Approved post from <@${flag.authorId}>:\n${flag.content}\n\n— Approved by <@${interaction.user.id}>${note ? `: ${note}` : ''}`,
+            username: WEBHOOK_NAME
+          };
+          if (flag.attachmentUrls && flag.attachmentUrls.length) {
+            msg.files = flag.attachmentUrls;
+          }
+          await hook.send(msg);
+        }
+        flag.status = 'approved';
+        await redis.set(`flag:${messageId}`, JSON.stringify(flag));
+        await redis.zRem('autoApproveQueue', messageId).catch(() => {});
+      } catch (err) {
+        console.error('Approve & Repost failed', err);
+      }
+      await interaction.reply({ content: 'Reposted.', ephemeral: true });
+      await logAction(interaction.client, 'approveRepost', `<@${flag.authorId}>`, interaction.user, `<#${flag.channelId}>`, 'approved', flag.content, `Rule IDs: ${flag.ruleIds.join(',')}`);
     }
-
-    // clean up: delete mod-alert message
-    await modAlert.delete().catch(console.error);
-
   } catch (err) {
     console.error('Moderation action error:', err);
     if (!interaction.replied) {

--- a/moderation/moderationScanner.js
+++ b/moderation/moderationScanner.js
@@ -4,120 +4,130 @@ const path = require('node:path');
 const fs = require('fs');
 const yaml = require('js-yaml');
 
-const MOD_CHANNEL_ID      = '1008371145793351740';
-const WEBHOOK_NAME        = 'ModBotRelay';
-// Local avatar image path (PNG/JPEG) in your project
-const WEBHOOK_AVATAR_PATH = path.join(__dirname, '../assets/modbot_avatar.png');
+const redis = require('../utils/redis');
+const getOrCreateWebhook = require('../utils/webhooks');
 
-// Use absolute path based on this file's directory
+const MOD_CHANNEL_ID      = '1008371145793351740';
+const LOG_CHANNEL_ID      = process.env.LOG_CHANNEL_ID || '983865514751320124';
+const AUTO_APPROVE_HOURS  = parseInt(process.env.AUTO_APPROVE_HOURS || '24', 10);
 const RULE_FILE = path.join(__dirname, '../config/mod_rules.yaml');
 
-// Load and compile once at module import time
+// Load rules with priority & action
 let compiledRules = [];
 try {
   const raw = fs.readFileSync(RULE_FILE, 'utf8');
   const parsed = yaml.load(raw);
-  const scamRules = parsed.rules || [];
-  compiledRules = scamRules.map(rule => ({
-    id:     rule.id,
-    action: rule.action,
+  const rules = parsed.rules || [];
+  compiledRules = rules.map(rule => ({
+    id: rule.id,
+    action: rule.action || 'flag_and_hide',
     reason: rule.reason,
-    regex:  new RegExp(rule.pattern, 'i')
+    priority: rule.priority || 'primary',
+    regex: new RegExp(rule.pattern, 'i')
   }));
-  console.log(`Loaded ${compiledRules.length} scam rules.`);
+  console.log(`Loaded ${compiledRules.length} mod rules.`);
 } catch (err) {
-  console.error('❌ Error loading scam rules:', err);
+  console.error('❌ Error loading mod rules:', err);
   process.exit(1);
 }
 
-// Preload avatar buffer
-let avatarBuffer;
-try {
-  avatarBuffer = fs.readFileSync(WEBHOOK_AVATAR_PATH);
-} catch (err) {
-  console.warn('🚧 Could not load webhook avatar from assets, falling back to bot avatar');
-  avatarBuffer = null;
-}
-
 module.exports = async function handleMessageModeration(client, message) {
-  // Ignore bots and DMs
   if (message.author.bot || !message.guild) return;
-
   const content = message.content;
-  const match = compiledRules.find(r => r.regex.test(content));
-  if (!match) return;
+  const matches = compiledRules.filter(r => r.regex.test(content));
+  if (!matches.length) return;
 
-  // Hide the flagged message until review
-  try {
-    await message.delete();
-  } catch (delErr) {
-    console.error('Failed to delete flagged message:', delErr);
+  const deleteMessage = matches.some(r => r.priority === 'primary' && r.action === 'flag_and_hide');
+  const holdReview = matches.some(r => r.action === 'hold_for_review');
+  const allSecondary = matches.every(r => r.priority === 'secondary');
+  const softFlag = !deleteMessage && (holdReview || allSecondary || matches.every(r => r.action === 'flag_only'));
+
+  const record = {
+    messageId: message.id,
+    channelId: message.channel.id,
+    guildId: message.guild.id,
+    authorId: message.author.id,
+    content: content.slice(0, 2000),
+    attachmentUrls: [...message.attachments.values()].map(a => a.url),
+    ruleIds: matches.map(r => r.id),
+    priorities: matches.map(r => r.priority),
+    actions: matches.map(r => r.action),
+    status: 'pending',
+    createdAt: Date.now()
+  };
+  if (softFlag) {
+    record.autoApproveAt = Date.now() + AUTO_APPROVE_HOURS * 3600 * 1000;
+  }
+  await redis.set(`flag:${message.id}`, JSON.stringify(record), { EX: 60 * 60 * 24 * 7 });
+  if (softFlag) {
+    await redis.zAdd('autoApproveQueue', { score: record.autoApproveAt, value: message.id });
+  }
+
+  if (deleteMessage) {
+    try { await message.delete(); } catch (e) { console.error('Failed to delete flagged message:', e); }
   }
 
   try {
     const modChannel = await client.channels.fetch(MOD_CHANNEL_ID).catch(() => null);
     if (!modChannel || !modChannel.isTextBased()) return;
-
-    // Find existing webhook
-    let hook;
-    const webhooks = await modChannel.fetchWebhooks().catch(() => null);
-    if (webhooks) {
-      hook = webhooks.find(h => h.name === WEBHOOK_NAME);
-    }
-
-    // Create webhook if none exists
-    if (!hook) {
-      const createOpts = { 
-        name: WEBHOOK_NAME, 
-        reason: 'Auto-moderation alerts' 
-      };
-      if (avatarBuffer) {
-        createOpts.avatar = avatarBuffer;
-      }
-      hook = await modChannel.createWebhook(createOpts).catch(err => {
-        console.error('Failed to create mod webhook:', err);
-        return null;
-      });
-    }
-
+    const hook = await getOrCreateWebhook(modChannel);
     if (!hook) return;
 
-    // Update existing webhook's avatar if we have a buffer
-    if (avatarBuffer) {
-      await hook.edit({ avatar: avatarBuffer }).catch(err => {
-        console.error('Failed to update mod webhook avatar:', err);
-      });
-    }
-
-    // Build embed and action row
+    const detectedPriority = deleteMessage ? 'primary' : 'secondary';
     const embed = new EmbedBuilder()
-      .setColor(0xff0000)
-      .setTitle('🚨 Potential Scam Message Detected')
-      .setDescription('This message was removed. If approved, the user will need to repost their content via ModBot.')
+      .setColor(deleteMessage ? 0xff0000 : 0xffa500)
+      .setTitle('🚨 Message Flagged')
       .addFields(
-        { name: 'User',    value: `${message.author.tag} (<@${message.author.id}>)`, inline: false },
-        { name: 'Channel', value: `<#${message.channel.id}>`,                         inline: false },
-        { name: 'Reason',  value: match.reason,                                       inline: false },
-        { name: 'Content', value: content.slice(0, 1000),                             inline: false }
+        { name: 'User', value: `${message.author.tag} (<@${message.author.id}>)`, inline: false },
+        { name: 'Channel', value: `<#${message.channel.id}>`, inline: false },
+        { name: 'Reason(s)', value: matches.map(m => m.reason).join('; '), inline: false },
+        { name: 'Content', value: content.slice(0, 1000) || '(none)', inline: false },
+        { name: 'Detected priority', value: detectedPriority, inline: false }
       )
-      .setFooter({ text: `Rule ID: ${match.id}` })
+      .setFooter({ text: `Rule IDs: ${matches.map(m => m.id).join(',')}` })
       .setTimestamp();
 
-    const row = new ActionRowBuilder().addComponents(
-      new ButtonBuilder().setCustomId(`warn_${message.id}`).setLabel('⚠️ Warn').setStyle(ButtonStyle.Primary),
-      new ButtonBuilder().setCustomId(`ban_${message.id}`).setLabel('🔨 Ban').setStyle(ButtonStyle.Danger),
-      new ButtonBuilder().setCustomId(`allow_${message.id}`).setLabel('✅ Allow').setStyle(ButtonStyle.Success)
-    );
+    const row = new ActionRowBuilder();
+    row.addComponents(new ButtonBuilder().setCustomId(`warn_${message.id}`).setLabel('⚠️ Warn').setStyle(ButtonStyle.Primary));
+    row.addComponents(new ButtonBuilder().setCustomId(`ban_${message.id}`).setLabel('🔨 Ban').setStyle(ButtonStyle.Danger));
+    if (deleteMessage) {
+      row.addComponents(new ButtonBuilder().setCustomId(`allow_${message.id}`).setLabel('✅ Allow').setStyle(ButtonStyle.Success));
+      row.addComponents(new ButtonBuilder().setCustomId(`approveRepost_${message.id}`).setLabel('Approve & Repost').setStyle(ButtonStyle.Secondary));
+    } else {
+      row.addComponents(new ButtonBuilder().setCustomId(`delete_${message.id}`).setLabel('🗑️ Delete').setStyle(ButtonStyle.Danger));
+      row.addComponents(new ButtonBuilder().setCustomId(`approve_${message.id}`).setLabel('Approve').setStyle(ButtonStyle.Success));
+      row.addComponents(new ButtonBuilder().setCustomId(`approveRepost_${message.id}`).setLabel('Approve & Repost').setStyle(ButtonStyle.Secondary));
+    }
 
-    // Send via webhook, using the webhook's configured avatar
-    await hook.send({
-      username:  WEBHOOK_NAME,
-      avatarURL: null,
-      embeds:    [embed],
-      components:[row]
-    });
-
+    await hook.send({ username: 'ModBotRelay', embeds: [embed], components: [row] });
   } catch (err) {
     console.error('Error sending mod alert via webhook:', err);
+  }
+
+  // Notify admins for soft flags
+  if (softFlag) {
+    const adminIds = (process.env.ADMIN_NOTIFY_USER_IDS || '').split(',').filter(Boolean);
+    if (adminIds.length) {
+      const notifyEmbed = new EmbedBuilder()
+        .setTitle('Soft Flag Created')
+        .setColor(0xffa500)
+        .setDescription(content.slice(0, 1000) || '(none)')
+        .addFields(
+          { name: 'Author', value: `<@${message.author.id}>`, inline: true },
+          { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
+          { name: 'Rules', value: matches.map(m => m.id).join(', '), inline: false },
+          { name: 'Auto-approve', value: `<t:${Math.floor(record.autoApproveAt/1000)}:R>`, inline: false }
+        );
+      for (const id of adminIds) {
+        const user = await client.users.fetch(id).catch(() => null);
+        if (user) {
+          await user.send({ embeds: [notifyEmbed] }).catch(async () => {
+            const logChannel = await client.channels.fetch(LOG_CHANNEL_ID).catch(() => null);
+            const hook = logChannel ? await getOrCreateWebhook(logChannel) : null;
+            if (hook) await hook.send({ embeds: [notifyEmbed], username: 'ModBot' });
+          });
+        }
+      }
+    }
   }
 };

--- a/utils/webhooks.js
+++ b/utils/webhooks.js
@@ -1,0 +1,28 @@
+const { ChannelType } = require('discord.js');
+const path = require('node:path');
+const fs = require('fs');
+
+const WEBHOOK_NAME = 'ModBotRelay';
+const AVATAR_PATH = path.join(__dirname, '../assets/modbot_avatar.png');
+let avatarBuffer;
+try {
+  avatarBuffer = fs.readFileSync(AVATAR_PATH);
+} catch {
+  avatarBuffer = null;
+}
+
+module.exports = async function getOrCreateWebhook(channel) {
+  if (!channel || channel.type !== ChannelType.GuildText) return null;
+  let hook;
+  const webhooks = await channel.fetchWebhooks().catch(() => null);
+  if (webhooks) hook = webhooks.find(h => h.name === WEBHOOK_NAME);
+  if (!hook) {
+    const options = { name: WEBHOOK_NAME };
+    if (avatarBuffer) options.avatar = avatarBuffer;
+    hook = await channel.createWebhook(options).catch(() => null);
+  }
+  if (hook && avatarBuffer) {
+    await hook.edit({ avatar: avatarBuffer }).catch(() => {});
+  }
+  return hook;
+};


### PR DESCRIPTION
## Summary
- persist moderation flag records with priority and actions
- add approve & repost workflow and auto-approve worker
- notify admins and document required permissions

## Testing
- `npm test` (fails: Missing script "test")
- `node --check moderation/moderationActions.js`
- `node --check moderation/moderationScanner.js`
- `node --check moderation/autoApproveWorker.js`
- `node --check utils/webhooks.js`
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_689a0b6750dc8333b775c99e6a95435f