### PR TITLE
fix: include js-yaml dependency for auto moderator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "express": "5.1.0",
         "helmet": "^8.1.0",
         "ioredis": "5.6.1",
+        "js-yaml": "^4.1.0",
         "langchain": "^0.3.29",
         "mammoth": "1.9.0",
         "mongodb": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "5.1.0",
     "helmet": "^8.1.0",
     "ioredis": "5.6.1",
+    "js-yaml": "^4.1.0",
     "langchain": "0.3.29",
     "mammoth": "1.9.0",
     "mongodb": "6.17.0",


### PR DESCRIPTION
## Summary
- add missing `js-yaml` dependency required by the auto-moderation scanner

## Testing
- `node index.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68ac711563c483338f1cfe998f6f7c94