### PR TITLE
fix: avoid redis circular dependency

### DIFF
--- a/commands/sessionRewards.js
+++ b/commands/sessionRewards.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-inline-comments */
 const { SlashCommandBuilder } = require('discord.js');
-// Assuming Redis setup is already done and client is available as redisClient
-const { redis } = require('../index');
+// Use the shared Redis client directly to avoid circular dependencies
+const redis = require('../utils/redis');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/events/messageCreate/dmFollowup.js
+++ b/events/messageCreate/dmFollowup.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-inline-comments */
-const { redis } = require('../../index'); // shared Redis client
+const redis = require('../../utils/redis'); // shared Redis client
 const Adventurer = require('../../models/adventurers');
 
 module.exports = {


### PR DESCRIPTION
## Summary
- import Redis client directly from utils module to remove circular dependency warnings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c5fd6708333a7ad0789fe702d90